### PR TITLE
By default, do not store user & item representations at each time step

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx_rtd_theme",
     "sphinx.ext.napoleon",
-    "sphinx.ext.mathjax"
+    "sphinx.ext.mathjax",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -60,6 +60,12 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
         measurements: list
             List of metrics to monitor.
 
+        record_base_state: bool (optional, default: False)
+            If True, the system will record at each time step its internal
+            representation of users profiles and item profiles, as well as the
+            true user profiles and item profiles. It will also record the
+            predicted user-item scores at each time step.
+
         system_state: list
             List of system state components to monitor.
 
@@ -134,6 +140,7 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
         num_items_per_iter,
         probabilistic_recommendations=False,
         measurements=None,
+        record_base_state=False,
         system_state=None,
         verbose=False,
         score_fn=inner_product,
@@ -194,12 +201,13 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
 
         # system state
         SystemStateModule.__init__(self)
-        self.add_state_variable(
-            self.users_hat,
-            self.users,
-            self.items_hat,
-            self.predicted_scores,
-        )
+        if record_base_state:
+            self.add_state_variable(
+                self.users_hat,
+                self.users,
+                self.items_hat,
+                self.predicted_scores,
+            )
         if system_state is not None:
             self.add_state_variable(*system_state)
 

--- a/trecs/tests/test_BassModel.py
+++ b/trecs/tests/test_BassModel.py
@@ -174,8 +174,8 @@ class TestBassModel:
     def test_seeding(self, seed=None, items=None, users=None):
         if seed is None:
             seed = np.random.randint(100000)
-        s1 = BassModel(seed=seed)
-        s2 = BassModel(seed=seed)
+        s1 = BassModel(seed=seed, record_base_state=True)
+        s2 = BassModel(seed=seed, record_base_state=True)
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)
@@ -192,8 +192,8 @@ class TestBassModel:
             items = np.random.randint(1, 1000)
         if users is None:
             users = np.random.randint(1, 100)
-        s1 = BassModel(seed=seed, num_users=users, num_items=items)
-        s2 = BassModel(seed=seed, num_users=users, num_items=items)
+        s1 = BassModel(seed=seed, num_users=users, num_items=items, record_base_state=True)
+        s2 = BassModel(seed=seed, num_users=users, num_items=items, record_base_state=True)
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)

--- a/trecs/tests/test_ContentFiltering.py
+++ b/trecs/tests/test_ContentFiltering.py
@@ -256,8 +256,8 @@ class TestContentFiltering:
     def test_seeding(self, seed=None, items=None, users=None):
         if seed is None:
             seed = np.random.randint(100000)
-        s1 = ContentFiltering(seed=seed)
-        s2 = ContentFiltering(seed=seed)
+        s1 = ContentFiltering(seed=seed, record_base_state=True)
+        s2 = ContentFiltering(seed=seed, record_base_state=True)
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)
@@ -274,8 +274,8 @@ class TestContentFiltering:
             items = np.random.randint(1, 1000)
         if users is None:
             users = np.random.randint(1, 100)
-        s1 = ContentFiltering(seed=seed, num_users=users, num_items=items)
-        s2 = ContentFiltering(seed=seed, num_users=users, num_items=items)
+        s1 = ContentFiltering(seed=seed, num_users=users, num_items=items, record_base_state=True)
+        s2 = ContentFiltering(seed=seed, num_users=users, num_items=items, record_base_state=True)
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)

--- a/trecs/tests/test_PopularityRecommender.py
+++ b/trecs/tests/test_PopularityRecommender.py
@@ -130,8 +130,12 @@ class TestPopularityRecommender:
             items = np.random.randint(10, 1000)
         if users is None:
             users = np.random.randint(10, 100)
-        s1 = PopularityRecommender(seed=seed, num_users=users, num_items=items, record_base_state=True)
-        s2 = PopularityRecommender(seed=seed, num_users=users, num_items=items, record_base_state=True)
+        s1 = PopularityRecommender(
+            seed=seed, num_users=users, num_items=items, record_base_state=True
+        )
+        s2 = PopularityRecommender(
+            seed=seed, num_users=users, num_items=items, record_base_state=True
+        )
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)

--- a/trecs/tests/test_PopularityRecommender.py
+++ b/trecs/tests/test_PopularityRecommender.py
@@ -112,8 +112,8 @@ class TestPopularityRecommender:
     def test_seeding(self, seed=None, items=None, users=None):
         if seed is None:
             seed = np.random.randint(100000)
-        s1 = PopularityRecommender(seed=seed)
-        s2 = PopularityRecommender(seed=seed)
+        s1 = PopularityRecommender(seed=seed, record_base_state=True)
+        s2 = PopularityRecommender(seed=seed, record_base_state=True)
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)
@@ -130,8 +130,8 @@ class TestPopularityRecommender:
             items = np.random.randint(10, 1000)
         if users is None:
             users = np.random.randint(10, 100)
-        s1 = PopularityRecommender(seed=seed, num_users=users, num_items=items)
-        s2 = PopularityRecommender(seed=seed, num_users=users, num_items=items)
+        s1 = PopularityRecommender(seed=seed, num_users=users, num_items=items, record_base_state=True)
+        s2 = PopularityRecommender(seed=seed, num_users=users, num_items=items, record_base_state=True)
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)

--- a/trecs/tests/test_SocialFiltering.py
+++ b/trecs/tests/test_SocialFiltering.py
@@ -184,8 +184,8 @@ class TestSocialFiltering:
     def test_seeding(self, seed=None, items=None, users=None):
         if seed is None:
             seed = np.random.randint(100000)
-        s1 = SocialFiltering(seed=seed)
-        s2 = SocialFiltering(seed=seed)
+        s1 = SocialFiltering(seed=seed, record_base_state=True)
+        s2 = SocialFiltering(seed=seed, record_base_state=True)
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)
@@ -202,8 +202,8 @@ class TestSocialFiltering:
             items = np.random.randint(1, 1000)
         if users is None:
             users = np.random.randint(1, 100)
-        s1 = SocialFiltering(seed=seed, num_users=users, num_items=items)
-        s2 = SocialFiltering(seed=seed, num_users=users, num_items=items)
+        s1 = SocialFiltering(seed=seed, num_users=users, num_items=items, record_base_state=True)
+        s2 = SocialFiltering(seed=seed, num_users=users, num_items=items, record_base_state=True)
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)

--- a/trecs/tests/test_measurements.py
+++ b/trecs/tests/test_measurements.py
@@ -78,7 +78,7 @@ class TestMeasurementModule:
         if timesteps is None:
             timesteps = np.random.randint(2, 100)
 
-        s = SocialFiltering()
+        s = SocialFiltering(record_base_state=True)
         state_mappings = {
             "predicted_user_profiles": s.users_hat,
             "actual_user_scores": s.users.actual_user_scores,

--- a/trecs/utils.py
+++ b/trecs/utils.py
@@ -171,7 +171,7 @@ def get_first_valid(*args):
 
 def all_besides_none_equal(*args):
     """Return True if all of the (non-None) elements are equal"""
-    non_none = list(filter(None, args))
+    non_none = list(filter(lambda x: x is not None, args))
     for i, arg in enumerate(non_none):
         if i + 1 < len(non_none) and arg != args[i + 1]:
             print(arg)
@@ -181,7 +181,7 @@ def all_besides_none_equal(*args):
 
 def non_none_values(*args):
     """Return True if all of the (non-None) elements are equal"""
-    return set(filter(None, args))
+    return set(filter(lambda x: x is not None, args))
 
 
 def all_none(*args):


### PR DESCRIPTION
When running long simulations with large #s of users and items, the Python process is often killed because it takes up too much memory. The most likely reason is that we are storing (by default) the (true/predicted) user profiles, the (true/predicted) item attributes, and the predicted user-item scores. 

This PR changes the default behavior so these attributes are not stored by default. (I also use this PR to correct some tests that were failing probabilistically!)