### PR TITLE
Close logging file handler upon garbage collection

### DIFF
--- a/trecs/logging.py
+++ b/trecs/logging.py
@@ -26,6 +26,11 @@ class VerboseMode(ABC):
         """ Log given message"""
         self._logger.log(msg)
 
+    def close(self):
+        """ Close the logging file handler """
+        self._logger.handler.close()
+        self._logger.logger.removeHandler(self._logger.handler)
+
 
 class DebugLogger:
     """ Class to configure debug logging module """

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -241,6 +241,12 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
         else:
             self.log("Seed was not set.")
 
+    def __del__(self):
+        """
+        Closes the logging handler upon garbage collection.
+        """
+        self.close()
+
     def update_predicted_scores(self):
         """
         Updates scores predicted by the system based on past interactions for

--- a/trecs/tests/test_recommender.py
+++ b/trecs/tests/test_recommender.py
@@ -1,5 +1,6 @@
 from trecs.models import BaseRecommender
 import numpy as np
+import pytest
 
 
 class DummyRecommender(BaseRecommender):
@@ -47,3 +48,12 @@ class TestBaseRecommender:
         dummy.run(5, repeated_items=True)  # run 5 timesteps
         # check that no users are recorded as having interacted with items
         assert (dummy.indices == -1).sum() == 0
+
+    def test_closed_logger(self):
+        dummy = DummyRecommender(self.users_hat, self.items_hat, self.users, self.items, 10, 50, 5)
+        dummy.run(5, repeated_items=True)  # run 5 timesteps
+        logger = dummy._logger.logger  # pylint: disable=protected-access
+        assert len(logger.handlers) == 1  # before garbage collection
+        del dummy
+        # after garbage collection, handler should be closed
+        assert len(logger.handlers) == 0

--- a/trecs/tests/test_recommender.py
+++ b/trecs/tests/test_recommender.py
@@ -53,7 +53,8 @@ class TestBaseRecommender:
         dummy = DummyRecommender(self.users_hat, self.items_hat, self.users, self.items, 10, 50, 5)
         dummy.run(5, repeated_items=True)  # run 5 timesteps
         logger = dummy._logger.logger  # pylint: disable=protected-access
-        assert len(logger.handlers) == 1  # before garbage collection
+        handler = dummy._logger.handler  # pylint: disable=protected-access
+        assert len(logger.handlers) > 0  # before garbage collection
         del dummy
         # after garbage collection, handler should be closed
-        assert len(logger.handlers) == 0
+        assert handler not in logger.handlers


### PR DESCRIPTION
When running many simulations, often this error occurs:

![image](https://user-images.githubusercontent.com/5581093/98873882-04a5c380-242e-11eb-968b-52b577e7aebb.png)

The solution is to close the logging file handler upon garbage collection. Otherwise, many file handlers will accumulate without ever being closed, causing this memory error!