### PR TITLE
Reduce logging for speed/efficiency reasons

### DIFF
--- a/trecs/components/socialgraph.py
+++ b/trecs/components/socialgraph.py
@@ -45,7 +45,7 @@ class BinarySocialGraph(VerboseMode):
             )
         if self.users_hat[following_index, user_index] == 0:
             self.users_hat[following_index, user_index] = 1
-        else:
+        elif self.is_verbose():
             self.log("User %d was already following user %d" % (following_index, user_index))
 
     def unfollow(self, user_index, following_index):
@@ -75,7 +75,7 @@ class BinarySocialGraph(VerboseMode):
             )
         if self.users_hat[following_index, user_index] == 1:
             self.users_hat[following_index, user_index] = 0
-        else:
+        elif self.is_verbose():
             self.log("User %d was not following user %d" % (following_index, user_index))
 
     def add_friends(self, user1_index, user2_index):
@@ -105,11 +105,11 @@ class BinarySocialGraph(VerboseMode):
             )
         if self.users_hat[user1_index, user2_index] == 0:
             self.users_hat[user1_index, user2_index] = 1
-        else:
+        elif self.is_verbose():
             self.log("User %d was already following user %d" % (user2_index, user1_index))
         if self.users_hat[user2_index, user1_index] == 0:
             self.users_hat[user2_index, user1_index] = 1
-        else:
+        elif self.is_verbose():
             self.log("User %d was already following user %d" % (user1_index, user2_index))
 
     def remove_friends(self, user1_index, user2_index):
@@ -139,9 +139,9 @@ class BinarySocialGraph(VerboseMode):
             )
         if self.users_hat[user1_index, user2_index] == 1:
             self.users_hat[user1_index, user2_index] = 0
-        else:
+        elif self.is_verbose():
             self.log("User %d was not following user %d" % (user2_index, user1_index))
         if self.users_hat[user2_index, user1_index] == 1:
             self.users_hat[user2_index, user1_index] = 0
-        else:
+        elif self.is_verbose():
             self.log("User %d was not following user %d" % (user1_index, user2_index))

--- a/trecs/components/socialgraph.py
+++ b/trecs/components/socialgraph.py
@@ -46,7 +46,7 @@ class BinarySocialGraph(VerboseMode):
         if self.users_hat[following_index, user_index] == 0:
             self.users_hat[following_index, user_index] = 1
         elif self.is_verbose():
-            self.log("User %d was already following user %d" % (following_index, user_index))
+            self.log(f"User {following_index} was already following user {user_index}")
 
     def unfollow(self, user_index, following_index):
         """
@@ -76,7 +76,7 @@ class BinarySocialGraph(VerboseMode):
         if self.users_hat[following_index, user_index] == 1:
             self.users_hat[following_index, user_index] = 0
         elif self.is_verbose():
-            self.log("User %d was not following user %d" % (following_index, user_index))
+            self.log(f"User {following_index} was not following user {user_index}")
 
     def add_friends(self, user1_index, user2_index):
         """
@@ -106,11 +106,11 @@ class BinarySocialGraph(VerboseMode):
         if self.users_hat[user1_index, user2_index] == 0:
             self.users_hat[user1_index, user2_index] = 1
         elif self.is_verbose():
-            self.log("User %d was already following user %d" % (user2_index, user1_index))
+            self.log(f"User {user2_index} was already following user {user1_index}")
         if self.users_hat[user2_index, user1_index] == 0:
             self.users_hat[user2_index, user1_index] = 1
         elif self.is_verbose():
-            self.log("User %d was already following user %d" % (user1_index, user2_index))
+            self.log(f"User {user1_index} was already following user {user2_index}")
 
     def remove_friends(self, user1_index, user2_index):
         """
@@ -140,8 +140,8 @@ class BinarySocialGraph(VerboseMode):
         if self.users_hat[user1_index, user2_index] == 1:
             self.users_hat[user1_index, user2_index] = 0
         elif self.is_verbose():
-            self.log("User %d was not following user %d" % (user2_index, user1_index))
+            self.log(f"User {user2_index} was not following user {user1_index}")
         if self.users_hat[user2_index, user1_index] == 1:
             self.users_hat[user2_index, user1_index] = 0
         elif self.is_verbose():
-            self.log("User %d was not following user %d" % (user1_index, user2_index))
+            self.log(f"User {user1_index} was not following user {user2_index}")

--- a/trecs/components/users.py
+++ b/trecs/components/users.py
@@ -311,10 +311,12 @@ class Users(BaseComponent):  # pylint: disable=too-many-ancestors
             raise ValueError("Items can't be None")
         reshaped_user_vector = self.user_vector.reshape((items_shown.shape[0], 1))
         user_interactions = self.actual_user_scores[reshaped_user_vector, items_shown]
-        self.log("User scores for given items are:\n" + str(user_interactions))
         sorted_user_preferences = user_interactions.argsort()[:, -1]
         interactions = items_shown[self.user_vector, sorted_user_preferences]
-        self.log("Users interact with the following items respectively:\n" + str(interactions))
+        # logging information if requested
+        if self.is_verbose():
+            self.log("User scores for given items are:\n" + str(user_interactions))
+            self.log("Users interact with the following items respectively:\n" + str(interactions))
         if self.drift > 0:
             if item_attributes is None:
                 raise ValueError("Item attributes can't be None if user preferences are dynamic")

--- a/trecs/components/users.py
+++ b/trecs/components/users.py
@@ -315,8 +315,8 @@ class Users(BaseComponent):  # pylint: disable=too-many-ancestors
         interactions = items_shown[self.user_vector, sorted_user_preferences]
         # logging information if requested
         if self.is_verbose():
-            self.log("User scores for given items are:\n" + str(user_interactions))
-            self.log("Users interact with the following items respectively:\n" + str(interactions))
+            self.log(f"User scores for given items are:\n{str(user_interactions)}")
+            self.log(f"Users interact with the following items respectively:\n{str(interactions)}")
         if self.drift > 0:
             if item_attributes is None:
                 raise ValueError("Item attributes can't be None if user preferences are dynamic")

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -243,11 +243,11 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
         self.indices = np.tile(np.arange(num_items), (num_users, 1))
         if self.is_verbose():
             self.log("Recommender system ready")
-            self.log("Num items: %d" % self.num_items)
-            self.log("Users: %d" % self.num_users)
-            self.log("Items per iter: %d" % self.num_items_per_iter)
+            self.log(f"Num items: {self.num_items}")
+            self.log(f"Users: {self.num_users}")
+            self.log(f"Items per iter: {self.num_items_per_iter}")
             if seed is not None:
-                self.log("Set seed to %d" % seed)
+                self.log(f"Set seed to {seed}")
             else:
                 self.log("Seed was not set.")
 

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -273,8 +273,8 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
         if self.is_verbose():
             self.log(
                 "System updates predicted scores given by users (rows) "
-                + "to items (columns):\n"
-                + str(predicted_scores)
+                "to items (columns):\n"
+                f"{str(predicted_scores)}"
             )
         assert predicted_scores is not None
         if self.predicted_scores is None:
@@ -329,9 +329,9 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
         permutation = s_filtered.argsort()
         rec = item_indices[row, permutation]
         if self.is_verbose():
-            self.log("Row:\n" + str(row))
-            self.log("Item indices:\n" + str(item_indices))
-            self.log("Items ordered by preference (low to high) for each user:\n" + str(rec))
+            self.log(f"Row:\n{str(row)}")
+            self.log(f"Item indices:\n{str(item_indices)}")
+            self.log(f"Items ordered by preference (low to high) for each user:\n{str(rec)}")
         if self.probabilistic_recommendations:
             # the recommended items will not be exactly determined by
             # predicted score; instead, we will sample from the sorted list


### PR DESCRIPTION
Simple PR to address issue #64 . We opt for the simplest solution, which is to only run log statements if the verbose mode is set to `True`. This avoids possibly expensive operations of "stringifying" potentially large numpy matrices. I also convert our print statements across the logging statements to use Python 3 format strings.