### PR TITLE
Fix package conflicts in testing file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,13 +20,13 @@ If you do not have Python 3.7+ installed, you can create a new environment with 
 
     conda create --name py37 python=3.7
 
-To ensure the example Jupyter notebooks run in your Python 3.7 environment, follow `the instructions from this blog post`_.
+To ensure the example Jupyter notebooks run in your Python 3.7 environment, follow `the instructions from this blog post`_. **Note**: you will also need ``pandas`` to run the example notebooks. As of December 2020, we recommend installing ``pandas v1.0.5`` using the command: ``pip install 'pandas==1.0.5'``. This will help avoid package conflicts between ``pandas`` and ``pylint`` if you also plan on contributing to ``trecs`` and running tests.
 
     .. _the instructions from this blog post: https://medium.com/@nrk25693/how-to-add-your-conda-environment-to-your-jupyter-notebook-in-just-4-steps-abeab8b8d084
 
-Currently, the simulator has only been tested extensively on MacOS 10.15.
+Currently, the simulator has only been tested extensively on MacOS 10.15 and Ubuntu 20.04.
 
-To install the simulator, you will need the Python package manager, pip. After activating your virtual environment, run the following commands in a terminal:
+To install the simulator, you will need the Python package manager, ``pip``. After activating your virtual environment, run the following commands in a terminal:
 
 ..  code-block:: bash
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
     install_requires=[
         "numpy>=1.17.0",
         "scipy>=1.4.1",
-        "pandas>=0.25.0",
         "networkx>=2.4",
         "tqdm>=4.46.0",
     ],

--- a/trecs/tests/test_BassModel.py
+++ b/trecs/tests/test_BassModel.py
@@ -189,7 +189,7 @@ class TestBassModel:
         test_helpers.assert_equal_system_state(systate1, systate2)
 
         if items is None:
-            items = np.random.randint(1, 1000)
+            items = np.random.randint(20, 1000)
         if users is None:
             users = np.random.randint(1, 100)
         s1 = BassModel(seed=seed, num_users=users, num_items=items, record_base_state=True)

--- a/trecs/tests/test_ContentFiltering.py
+++ b/trecs/tests/test_ContentFiltering.py
@@ -271,7 +271,7 @@ class TestContentFiltering:
         test_helpers.assert_equal_system_state(systate1, systate2)
 
         if items is None:
-            items = np.random.randint(1, 1000)
+            items = np.random.randint(20, 1000)
         if users is None:
             users = np.random.randint(1, 100)
         s1 = ContentFiltering(seed=seed, num_users=users, num_items=items, record_base_state=True)

--- a/trecs/tests/test_PopularityRecommender.py
+++ b/trecs/tests/test_PopularityRecommender.py
@@ -128,9 +128,9 @@ class TestPopularityRecommender:
         test_helpers.assert_equal_system_state(systate1, systate2)
 
         if items is None:
-            items = np.random.randint(10, 1000)
+            items = np.random.randint(20, 1000)
         if users is None:
-            users = np.random.randint(10, 100)
+            users = np.random.randint(20, 100)
         s1 = PopularityRecommender(
             seed=seed, num_users=users, num_items=items, record_base_state=True
         )

--- a/trecs/tests/test_SocialFiltering.py
+++ b/trecs/tests/test_SocialFiltering.py
@@ -200,7 +200,7 @@ class TestSocialFiltering:
         test_helpers.assert_equal_system_state(systate1, systate2)
 
         if items is None:
-            items = np.random.randint(1, 1000)
+            items = np.random.randint(20, 1000)
         if users is None:
             users = np.random.randint(1, 100)
         s1 = SocialFiltering(seed=seed, num_users=users, num_items=items, record_base_state=True)


### PR DESCRIPTION
Apparently, `pandas v1.1.0` doesn't play nicely with `pylint 2.6.0`. So I remove it from `setup.py`. `pandas` also isn't used anywhere in the `trecs` package (it's only used in the example notebooks), so as a matter of principle I don't think it should be in `setup.py`.

For future reference, `pandas v1.0.5` does seem to work well (see this [conversation](https://github.com/PyCQA/pylint/issues/3746)). Note to self: modify packages contributing.RST / readme.RST to address this potential issue...