### PR TITLE
Address logging issues

### DIFF
--- a/trecs/logging.py
+++ b/trecs/logging.py
@@ -34,8 +34,11 @@ class VerboseMode(ABC):
 
     def close(self):
         """ Close the logging file handler """
-        self._logger.handler.close()
-        self._logger.logger.removeHandler(self._logger.handler)
+        # occasionally verbose objects are created incidentally
+        # when performing matrix operations
+        if hasattr(self, "_logger"):
+            self._logger.handler.close()
+            self._logger.logger.removeHandler(self._logger.handler)
 
 
 class DebugLogger:

--- a/trecs/logging.py
+++ b/trecs/logging.py
@@ -11,6 +11,12 @@ class VerboseMode(ABC):
     def __init__(self, name, verbose=False):
         self._logger = DebugLogger(name, verbose)
 
+    def __del__(self):
+        """
+        Closes the logging handler upon garbage collection.
+        """
+        self.close()
+
     def set_verbose(self, toggle):
         """Toggle verbosity"""
         try:

--- a/trecs/models/content.py
+++ b/trecs/models/content.py
@@ -224,7 +224,7 @@ class ContentFiltering(BaseRecommender):
         interactions_per_user = np.zeros((self.num_users, self.num_items))
         interactions_per_user[self.users.user_vector, interactions] = 1
         user_attributes = np.dot(interactions_per_user, self.items_hat.T)
-        self.users_hat[:, :] = np.add(self.users_hat, user_attributes)
+        self.users_hat += user_attributes
 
     def process_new_items(self, new_items):
         """

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -248,12 +248,6 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
             else:
                 self.log("Seed was not set.")
 
-    def __del__(self):
-        """
-        Closes the logging handler upon garbage collection.
-        """
-        self.close()
-
     def initialize_user_scores(self):
         """
         If the Users object does not already have known user-item scores,

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -274,9 +274,7 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
         --------
             predicted_scores: :class:`~components.users.PredictedScores`
         """
-        user_profiles = self.users_hat
-        item_attributes = self.items_hat
-        predicted_scores = self.score_fn(user_profiles, item_attributes)
+        predicted_scores = self.score_fn(self.users_hat, self.items_hat)
         if self.is_verbose():
             self.log(
                 "System updates predicted scores given by users (rows) "

--- a/trecs/tests/test_components.py
+++ b/trecs/tests/test_components.py
@@ -19,3 +19,12 @@ class TestComponents:
         np.testing.assert_array_equal(profiles.state_history[0], np.zeros((5, 5)))
         np.testing.assert_array_equal(profiles.state_history[1], 1 * np.ones((5, 5)))
         np.testing.assert_array_equal(profiles.state_history[2], 2 * np.ones((5, 5)))
+
+    def test_closed_logger(self):
+        profiles = PredictedUserProfiles(np.zeros((5, 5)))
+        logger = profiles._logger.logger  # pylint: disable=protected-access
+        handler = profiles._logger.handler  # pylint: disable=protected-access
+        assert len(logger.handlers) > 0  # before garbage collection
+        del profiles
+        # after garbage collection, handler should be closed
+        assert handler not in logger.handlers


### PR DESCRIPTION
Oftentimes running large/repeated simulations results in an error that says something like: `Too many file handlers for "trecs.log"`. This is kind of a weird error to run into. I fixed a similar error in a previous PR, but have still seen this error popping up. I did some more digging and it turns out that for anything that inherits `VerboseMode`, a new handler is created for `trecs.log` and it is never closed. I edited `VerboseMode` so that upon garbage collection it automatically closes the file handler.

There are also a couple other line-item changes that just help prevent the creation of unnecessary `VerboseMode` objects. 