### PR TITLE
Item ordering effects in Chaney

### DIFF
--- a/trecs/components/users.py
+++ b/trecs/components/users.py
@@ -104,9 +104,10 @@ class Users(BaseComponent):  # pylint: disable=too-many-ancestors
             the item chosen will be a function of its index in the recommendation
             set and the underlying user-item score. (See Chaney et al. 2018
             for a description of this mechanism.) Concretely, the item chosen will
-            be according to :math:`i_u(t)=\\mathrm{argmax}_i( \\mathrm{rank}_{u,t}(i)^{\\alpha} \cdot S_{u,i}(t) )`,
-            where :math:`\\alpha` is the attention exponent and :math:`S_{u,i}(t)`
-            is the underlying user-item score.
+            be according to
+            :math:`i_u(t)=\\mathrm{argmax}_i( \\mathrm{rank}_{u,t}(i)^{\\alpha}
+            \\cdot S_{u,i}(t) )`, where :math:`\\alpha` is the attention exponent
+            and :math:`S_{u,i}(t)` is the underlying user-item score.
 
         score_fn: callable
             Function that is used to calculate each user's scores for each

--- a/trecs/components/users.py
+++ b/trecs/components/users.py
@@ -342,7 +342,7 @@ class Users(BaseComponent):  # pylint: disable=too-many-ancestors
         user_interactions = self.actual_user_scores[reshaped_user_vector, items_shown]
         if self.attention_exp != 0:
             idxs = np.arange(items_shown.shape[1]) + 1
-            multiplier = np.power(idxs, self.attemption)
+            multiplier = np.power(idxs, self.attention_exp)
             # multiply each row by the attention coefficient
             user_interactions = user_interactions * multiplier
         sorted_user_preferences = user_interactions.argsort()[:, -1]

--- a/trecs/components/users.py
+++ b/trecs/components/users.py
@@ -103,7 +103,10 @@ class Users(BaseComponent):  # pylint: disable=too-many-ancestors
             in the recommendation set affects the user's choice, in that
             the item chosen will be a function of its index in the recommendation
             set and the underlying user-item score. (See Chaney et al. 2018
-            for a description of this mechanism.)
+            for a description of this mechanism.) Concretely, the item chosen will
+            be according to :math:`i_u(t)=\\mathrm{argmax}_i( \\mathrm{rank}_{u,t}(i)^{\\alpha} \cdot S_{u,i}(t) )`,
+            where :math:`\\alpha` is the attention exponent and :math:`S_{u,i}(t)`
+            is the underlying user-item score.
 
         score_fn: callable
             Function that is used to calculate each user's scores for each

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -342,7 +342,9 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
             return rec[:, picks]
         else:
             # ensure that the highest scored items show up first
-            return np.fliplr(rec[:, -k:], )
+            return np.fliplr(
+                rec[:, -k:],
+            )
 
     def recommend(
         self,
@@ -424,9 +426,11 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
         items = np.zeros((self.num_users, self.num_items_per_iter), dtype=int)
         # generate indices for recommended and randomly interleaved columns
         col_idxs = np.zeros(self.num_items_per_iter, dtype=bool)
-        rand_col_idxs = self.random_state.choice(self.num_items_per_iter, size=num_new_items, replace=False)
+        rand_col_idxs = self.random_state.choice(
+            self.num_items_per_iter, size=num_new_items, replace=False
+        )
         col_idxs[rand_col_idxs] = True
-        items[:, ~col_idxs] = recommended # preserving relative order of recommended items
+        items[:, ~col_idxs] = recommended  # preserving relative order of recommended items
         items[:, col_idxs] = new_items
         if self.is_verbose():
             self.log(

--- a/trecs/tests/test_Users.py
+++ b/trecs/tests/test_Users.py
@@ -94,3 +94,24 @@ class TestUsers:
         normed_scores = np.array([[0.7620146], [0.82551582], [0.88901703], [0.95251825]])
 
         np.testing.assert_array_almost_equal(normed_values, normed_scores)
+
+    def test_attention(self):
+        num_users = 5
+        num_attr = 4
+        num_items = 5
+        users = Users(np.ones((num_users, num_attr)), attention_exp=-0.8)
+        items = np.ones((num_attr, num_items))
+        # item at index 1 has a slightly higher score, without the attentional
+        # mechanism, all users would score it the highest
+        items[:, 1] = 1.5
+        users.compute_user_scores(items)
+        items_shown = np.tile(np.arange(num_items), (num_users, 1))
+        feedback = users.get_user_feedback(items_shown=items_shown)
+        np.testing.assert_array_equal(feedback, np.zeros(num_users))
+
+        # when we turn user attention off, we should see that all users
+        # interact with item 1
+        users.attention_exp = 0
+        users.compute_user_scores(items)
+        feedback = users.get_user_feedback(items_shown=items_shown)
+        np.testing.assert_array_equal(feedback, np.ones(num_users))

--- a/trecs/tests/test_recommender.py
+++ b/trecs/tests/test_recommender.py
@@ -49,6 +49,23 @@ class TestBaseRecommender:
             # each user interacts with one new item
             assert (dummy.indices == -1).sum() == (i + 1) * 10
 
+    def test_item_order(self):
+        # items should be recommended in order of increasing user-item scores
+        self.items_hat = np.zeros(self.items_hat.shape)
+        self.items_hat[:, 0] = 100
+        self.items_hat[:, 1] = 200
+        self.items_hat[:, 2] = 300
+        self.items_hat[:, 3] = 400
+        self.items_hat[:, 4] = 500
+        dummy = DummyRecommender(self.users_hat, self.items_hat, self.users, self.items, 10, 50, 5)
+        num_users = self.users.shape[0]
+        # we expect every user to be recommended: 4, 3, 2, 1, 0
+        expected_rec = np.fliplr(np.tile(np.arange(5), (num_users, 1)))
+        recommended = dummy.generate_recommendations(k=5, item_indices=dummy.indices)
+        np.testing.assert_array_equal(recommended, expected_rec)
+        recommended = dummy.recommend()
+        np.testing.assert_array_equal(recommended, expected_rec)
+
     def test_repeated_items(self):
         # show 5 items per iteration
         dummy = DummyRecommender(self.users_hat, self.items_hat, self.users, self.items, 10, 50, 5)


### PR DESCRIPTION
A pretty small draft PR that shows the alterations I made to the guts of the library to account for item ordering effects. It requires changes to `BaseRecommender` as well as the `Users` class. Previously we discussed trying to keep all the changes for the Chaney replication contained within the notebook, but I don't know how you would alter `BaseRecommender` in a clean/understandable way in the notebook. It seems a little more tractable to write a custom `Users` class, but for convenience, I'm putting all the changes in this one PR.

Personally, I'm fine with merging this into the library rather than keeping it as separate custom code. The changes made in `BaseRecommender` are as valid a way as any to order the items presented to the users, and none of the default behavior of the `Users` class is altered. Furthermore, if this is merged into the library, the reproducibility aspect is much cleaner, as all you need for the reproduction is the `main` branch of `trecs` and the notebook, rather than this custom code.

Let me know what you think!