### PR TITLE
Sort user scores efficiently

### DIFF
--- a/trecs/components/users.py
+++ b/trecs/components/users.py
@@ -327,12 +327,12 @@ class Users(BaseComponent):  # pylint: disable=too-many-ancestors
         if items_shown is None:
             raise ValueError("Items can't be None")
         reshaped_user_vector = self.user_vector.reshape((items_shown.shape[0], 1))
-        user_interactions = self.actual_user_scores[reshaped_user_vector, items_shown]
-        sorted_user_preferences = user_interactions.argsort()[:, -1]
+        rec_item_scores = self.actual_user_scores[reshaped_user_vector, items_shown]
+        sorted_user_preferences = rec_item_scores.argmax(axis=1)
         interactions = items_shown[self.user_vector, sorted_user_preferences]
         # logging information if requested
         if self.is_verbose():
-            self.log(f"User scores for given items are:\n{str(user_interactions)}")
+            self.log(f"User scores for given items are:\n{str(rec_item_scores)}")
             self.log(f"Users interact with the following items respectively:\n{str(interactions)}")
         if self.drift > 0:
             if item_attributes is None:

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -323,15 +323,9 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
         row = np.repeat(self.users.user_vector, item_indices.shape[1])
         row = row.reshape((self.num_users, -1))
         s_filtered = self.predicted_scores[row, item_indices]
-        # scores are U x I; we can use argsort to sort the item indices
-        # from low to high scores
-        permutation = s_filtered.argsort()
-        rec = item_indices[row, permutation]
-        if self.is_verbose():
-            self.log(f"Row:\n{str(row)}")
-            self.log(f"Item indices:\n{str(item_indices)}")
-            self.log(f"Items ordered by preference (low to high) for each user:\n{str(rec)}")
         if self.probabilistic_recommendations:
+            permutation = s_filtered.argsort()
+            rec = item_indices[row, permutation]
             # the recommended items will not be exactly determined by
             # predicted score; instead, we will sample from the sorted list
             # such that higher-preference items get more probability mass
@@ -341,7 +335,17 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
             picks = np.random.choice(num_items_unseen, k, replace=False, p=probabilities)
             return rec[:, picks]
         else:
-            return rec[:, -k:]
+            # scores are U x I; we can use argpartition to take the top k scores
+            top_k = (-1 * s_filtered).argpartition(k - 1)[:, :k] # negate scores so indices go from highest to lowest
+            # now we sort within the top k
+            row = np.repeat(self.users.user_vector, k).reshape((self.num_users, -1))
+            sort_top_k = (-1 * s_filtered)[row, top_k].argsort() # again, indices should go from highest to lowest
+            rec = item_indices[row, top_k[row, sort_top_k]] # extract items such that rows go from highest scored to lowest-scored of top-k
+            if self.is_verbose():
+                self.log(f"Row:\n{str(row)}")
+                self.log(f"Item indices:\n{str(item_indices)}")
+                self.log(f"Top-k items ordered by preference (low to high) for each user:\n{str(rec)}")
+            return rec
 
     def recommend(
         self,

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -335,24 +335,25 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
             picks = np.random.choice(num_items_unseen, k, replace=False, p=probabilities)
             return rec[:, picks]
         else:
-<<<<<<< HEAD
             # scores are U x I; we can use argpartition to take the top k scores
-            top_k = (-1 * s_filtered).argpartition(k - 1)[:, :k] # negate scores so indices go from highest to lowest
+            top_k = (-1 * s_filtered).argpartition(k - 1)[
+                :, :k
+            ]  # negate scores so indices go from highest to lowest
             # now we sort within the top k
             row = np.repeat(self.users.user_vector, k).reshape((self.num_users, -1))
-            sort_top_k = (-1 * s_filtered)[row, top_k].argsort() # again, indices should go from highest to lowest
-            rec = item_indices[row, top_k[row, sort_top_k]] # extract items such that rows go from highest scored to lowest-scored of top-k
+            sort_top_k = (-1 * s_filtered)[
+                row, top_k
+            ].argsort()  # again, indices should go from highest to lowest
+            rec = item_indices[
+                row, top_k[row, sort_top_k]
+            ]  # extract items such that rows go from highest scored to lowest-scored of top-k
             if self.is_verbose():
                 self.log(f"Row:\n{str(row)}")
                 self.log(f"Item indices:\n{str(item_indices)}")
-                self.log(f"Top-k items ordered by preference (low to high) for each user:\n{str(rec)}")
+                self.log(
+                    f"Top-k items ordered by preference (low to high) for each user:\n{str(rec)}"
+                )
             return rec
-=======
-            # ensure that the highest scored items show up first
-            return np.fliplr(
-                rec[:, -k:],
-            )
->>>>>>> main
 
     def recommend(
         self,

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -336,14 +336,12 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
             return rec[:, picks]
         else:
             # scores are U x I; we can use argpartition to take the top k scores
-            top_k = (-1 * s_filtered).argpartition(k - 1)[
-                :, :k
-            ]  # negate scores so indices go from highest to lowest
+            negated_scores = -1 * s_filtered  # negate scores so indices go from highest to lowest
+            top_k = negated_scores.argpartition(k - 1)[:, :k]
             # now we sort within the top k
             row = np.repeat(self.users.user_vector, k).reshape((self.num_users, -1))
-            sort_top_k = (-1 * s_filtered)[
-                row, top_k
-            ].argsort()  # again, indices should go from highest to lowest
+            # again, indices should go from highest to lowest
+            sort_top_k = negated_scores[row, top_k].argsort()
             rec = item_indices[
                 row, top_k[row, sort_top_k]
             ]  # extract items such that rows go from highest scored to lowest-scored of top-k

--- a/trecs/tests/test_recommender.py
+++ b/trecs/tests/test_recommender.py
@@ -63,6 +63,8 @@ class TestBaseRecommender:
         expected_rec = np.fliplr(np.tile(np.arange(5), (num_users, 1)))
         recommended = dummy.generate_recommendations(k=5, item_indices=dummy.indices)
         np.testing.assert_array_equal(recommended, expected_rec)
+        recommended = dummy.generate_recommendations(k=2, item_indices=dummy.indices)
+        np.testing.assert_array_equal(recommended, expected_rec[:, :2])
         recommended = dummy.recommend()
         np.testing.assert_array_equal(recommended, expected_rec)
 


### PR DESCRIPTION
Currently, we make use of `np.argsort()` for two tasks that may become highly compute-intensive when we scale to large simulations. I reimplement these functions using `np.argpartition()` instead, which is an efficient way to retrieve the *top-k* elements without needing to sort all elements in an array.

The first task is when the recommender system serves recommendations. We use `argsort` to sort all the predicted user-item scores for each user, and then extract the *k* items with the highest scores. However, using `np.argpartition` is more efficient here; especially in the scenario where there is a huge number of items, extracting the top-k using `np.argpartition` is much quicker than sorting all 10,000 item scores for each user. (Note that for this task, after extracting the top-k, I use `np.argsort` to sort *within* the set of top-k so that the items are recommended in the correct ordering, from highest predicted score to lowest predicted score.)

The second task is when each user selects which item to interact with out of the items that were recommended. Once again, we use `np.argsort()` to sort all of the true underlying user-item scores. Instead, we can use `np.argmax` to pull out the item index with the highest predicted score.

I did some casual profiling using Jupyter Lab and the following snippet:
```
import trecs
import numpy as np
from trecs.models import ContentFiltering
num_users = 10000
num_items = 1000
num_attr = 10

def run_model():
    actual_users = np.random.rand(num_users, num_attr)
    actual_items = np.random.rand(num_attr, num_items)


    content = ContentFiltering(user_representation=actual_users, 
                               item_representation=actual_items, 
                               actual_item_representation=np.copy(actual_items), 
                               actual_user_representation=np.copy(actual_users))
    content.run(
        timesteps=10,
        train_between_steps=True
    )    


```
## Before change
```
%timeit -n 30 run_model()
> 30 loops, best of 5: 10.5 s per loop
```
## After change
```
%timeit -n 30 run_model()
> 30 loops, best of 5: 6.65 s per loop
```
Wow, we can reduce the time for large-scale simulations by almost 40%! 😱 🤯 