### PR TITLE
Increasing flexibility of T-RECS system for Chaney replication

### DIFF
--- a/examples/complete-guide.ipynb
+++ b/examples/complete-guide.ipynb
@@ -60,7 +60,7 @@
     "import trecs\n",
     "from trecs.models import ContentFiltering\n",
     "from trecs.random import Generator\n",
-    "from trecs.metrics import HomogeneityMeasurement, RecSimilarity, AverageFeatureScoreRange"
+    "from trecs.metrics import MSEMeasurement, HomogeneityMeasurement, RecSimilarity, AverageFeatureScoreRange"
    ]
   },
   {
@@ -74,13 +74,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 5/5 [00:00<00:00, 68.70it/s]\n"
+      "100%|██████████| 5/5 [00:00<00:00,  7.23it/s]\n"
      ]
     }
    ],
    "source": [
     "# Create ContentFiltering instance without arguments\n",
     "default_filtering = ContentFiltering()\n",
+    "# add an MSE measurement\n",
+    "default_filtering.add_metrics(MSEMeasurement())\n",
     "# Run for 5 time steps\n",
     "default_filtering.run(timesteps=5)"
    ]
@@ -130,27 +132,27 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>124.60279725267516</td>\n",
+       "      <td>126.05449491921866</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>150.5610615878324</td>\n",
+       "      <td>147.1055588270609</td>\n",
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>153.07753159337992</td>\n",
+       "      <td>147.87298364450393</td>\n",
        "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>152.3401336914828</td>\n",
+       "      <td>146.70261708806632</td>\n",
        "      <td>4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>150.30186728696842</td>\n",
+       "      <td>145.17831704557307</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -160,11 +162,11 @@
       "text/plain": [
        "                  mse  timesteps\n",
        "0                None          0\n",
-       "1  124.60279725267516          1\n",
-       "2   150.5610615878324          2\n",
-       "3  153.07753159337992          3\n",
-       "4   152.3401336914828          4\n",
-       "5  150.30186728696842          5"
+       "1  126.05449491921866          1\n",
+       "2   147.1055588270609          2\n",
+       "3  147.87298364450393          3\n",
+       "4  146.70261708806632          4\n",
+       "5  145.17831704557307          5"
       ]
      },
      "execution_count": 3,
@@ -411,23 +413,23 @@
      "output_type": "stream",
      "text": [
       "User representation (num_users x num_attributes):\n",
-      "[[0 1 0 3 2 2 3 2 2 3]\n",
-      " [1 0 2 2 0 3 3 0 3 0]\n",
-      " [1 1 2 1 2 0 0 2 2 0]\n",
-      " [3 1 3 2 0 2 1 1 2 0]\n",
-      " [3 0 1 1 2 3 1 2 2 3]]\n",
+      "[[0 0 0 3 2 2 3 1 3 2]\n",
+      " [1 2 0 1 0 0 3 0 0 0]\n",
+      " [0 0 3 3 2 2 2 0 1 0]\n",
+      " [3 0 2 1 1 3 2 2 2 2]\n",
+      " [1 2 1 3 1 1 0 2 0 0]]\n",
       "\n",
       "Item representation (num_attributes x num_items):\n",
-      "[[0 1 0 0 1 0 1 0 1 0 1 0 0 0 1]\n",
-      " [1 0 0 0 0 0 1 1 0 0 1 0 0 0 1]\n",
-      " [0 0 0 0 0 0 1 0 1 1 1 0 1 0 1]\n",
-      " [0 1 1 0 0 0 0 0 0 0 0 1 0 0 0]\n",
-      " [1 0 0 0 0 0 1 1 0 0 0 0 1 1 0]\n",
-      " [0 1 0 0 0 0 1 1 0 0 1 0 0 1 0]\n",
-      " [1 1 0 0 1 0 0 0 0 0 1 1 1 0 0]\n",
-      " [1 0 0 0 1 0 0 0 0 0 1 0 1 1 0]\n",
-      " [0 0 1 1 1 0 0 1 0 0 1 0 0 0 1]\n",
-      " [0 0 0 1 0 1 1 0 1 0 1 0 1 0 0]]\n"
+      "[[0 0 0 0 1 0 1 1 0 0 1 1 0 0 0]\n",
+      " [0 0 0 1 1 0 0 0 0 1 0 1 0 1 0]\n",
+      " [1 0 0 0 0 0 1 0 1 0 0 0 1 1 0]\n",
+      " [0 0 0 1 1 1 0 0 0 0 0 0 0 1 0]\n",
+      " [0 0 0 0 1 0 0 0 0 1 0 0 1 0 0]\n",
+      " [0 0 1 0 0 1 1 0 0 0 0 0 0 0 0]\n",
+      " [1 0 1 0 0 0 1 0 0 0 0 0 0 0 0]\n",
+      " [0 0 1 0 0 0 0 1 1 0 0 0 0 1 1]\n",
+      " [0 0 0 1 0 0 0 1 0 0 0 1 0 1 0]\n",
+      " [0 0 0 0 1 1 0 0 0 0 0 0 0 1 0]]\n"
      ]
     }
    ],
@@ -443,8 +445,9 @@
     "# We define item_representation using the Generator that comes with the framework\n",
     "# We assume a binary matrix with a binomial distribution\n",
     "\n",
-    "item_representation = Generator().binomial(n=1, p=.3,\n",
-    "                                           size=(number_of_attributes, number_of_items))\n",
+    "item_representation = Generator().binomial(\n",
+    "    n=1, p=.3, size=(number_of_attributes, number_of_items)\n",
+    ")\n",
     "# Note that this is equivalent to:\n",
     "# item_representation = np.random.Generator(np.random.MT19937()).binomial(n=1, p=.5, size=(...))\n",
     "\n",
@@ -535,7 +538,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 50/50 [00:00<00:00, 4787.80it/s]\n"
+      "100%|██████████| 50/50 [00:00<00:00, 2113.79it/s]\n"
      ]
     }
    ],
@@ -543,8 +546,29 @@
     "# let's initialize a model with both user_representation and item_representation defined above\n",
     "filtering = ContentFiltering(user_representation=user_representation,\n",
     "                            item_representation=item_representation)\n",
+    "filtering.add_metrics(MSEMeasurement()) # add MSE Measurement\n",
     "# Run the model for the predefined number of timesteps:\n",
     "filtering.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dtype('int64')"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "filtering.items_hat.dtype"
    ]
   },
   {
@@ -556,7 +580,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -592,22 +616,22 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>1.1520858423856952</td>\n",
+       "      <td>0.8620249744711203</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>1.1470475696258833</td>\n",
+       "      <td>0.8435037065913435</td>\n",
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>1.117040877176485</td>\n",
+       "      <td>0.8135091215562542</td>\n",
        "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>1.0829636182544558</td>\n",
+       "      <td>0.7826498881561971</td>\n",
        "      <td>4</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -617,13 +641,13 @@
       "text/plain": [
        "                  mse  timesteps\n",
        "0                None          0\n",
-       "1  1.1520858423856952          1\n",
-       "2  1.1470475696258833          2\n",
-       "3   1.117040877176485          3\n",
-       "4  1.0829636182544558          4"
+       "1  0.8620249744711203          1\n",
+       "2  0.8435037065913435          2\n",
+       "3  0.8135091215562542          3\n",
+       "4  0.7826498881561971          4"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -653,7 +677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -661,7 +685,7 @@
      "output_type": "stream",
      "text": [
       "The system is currently monitoring these metrics:\n",
-      "[<trecs.metrics.measurement.MSEMeasurement object at 0x7fbd9c89e690>]\n"
+      "[<trecs.metrics.measurement.MSEMeasurement object at 0x7f2f80731110>]\n"
      ]
     }
    ],
@@ -686,7 +710,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -694,7 +718,7 @@
      "output_type": "stream",
      "text": [
       "These are the current metrics:\n",
-      "[<trecs.metrics.measurement.MSEMeasurement object at 0x7fbd6123f7d0>, <trecs.metrics.measurement.HomogeneityMeasurement object at 0x7fbd6123f850>]\n"
+      "[<trecs.metrics.measurement.MSEMeasurement object at 0x7f2f803a3dd0>, <trecs.metrics.measurement.HomogeneityMeasurement object at 0x7f2f803a3a10>]\n"
      ]
     }
    ],
@@ -708,10 +732,11 @@
     "item_representation = Generator().normal(size=(number_of_attributes, number_of_items))\n",
     "filtering = ContentFiltering(num_users=number_of_users, num_items=number_of_items, \n",
     "                             num_attributes=number_of_attributes,\n",
-    "                             item_representation=item_representation)\n",
+    "                             item_representation=item_representation,\n",
+    "                             record_base_state=True)\n",
     "\n",
     "# This method accepts a variable number of metrics\n",
-    "filtering.add_metrics(HomogeneityMeasurement())\n",
+    "filtering.add_metrics(MSEMeasurement(), HomogeneityMeasurement())\n",
     "\n",
     "print(\"These are the current metrics:\")\n",
     "print(filtering.metrics)"
@@ -726,7 +751,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -734,7 +759,7 @@
      "output_type": "stream",
      "text": [
       "These are the current metrics:\n",
-      "[<trecs.metrics.measurement.MSEMeasurement object at 0x7fbd6123f7d0>, <trecs.metrics.measurement.HomogeneityMeasurement object at 0x7fbd6123f850>, <trecs.metrics.measurement.JaccardSimilarity object at 0x7fbd61238510>]\n"
+      "[<trecs.metrics.measurement.MSEMeasurement object at 0x7f2f803a3dd0>, <trecs.metrics.measurement.HomogeneityMeasurement object at 0x7f2f803a3a10>, <trecs.metrics.measurement.RecSimilarity object at 0x7f2f803a3090>]\n"
      ]
     }
    ],
@@ -755,7 +780,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -764,14 +789,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 5/5 [00:00<00:00, 64.77it/s]\n"
+      "100%|██████████| 5/5 [00:00<00:00, 48.35it/s]\n"
      ]
     },
     {
@@ -797,7 +822,7 @@
        "      <th></th>\n",
        "      <th>mse</th>\n",
        "      <th>homogeneity</th>\n",
-       "      <th>jaccard_similarity</th>\n",
+       "      <th>rec_similarity</th>\n",
        "      <th>afsr</th>\n",
        "      <th>timesteps</th>\n",
        "    </tr>\n",
@@ -813,42 +838,42 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>1.5139009543444946</td>\n",
-       "      <td>-45.5</td>\n",
-       "      <td>1.000000000000011</td>\n",
-       "      <td>9.475716982097305</td>\n",
+       "      <td>1.3177271448229297</td>\n",
+       "      <td>-49.0</td>\n",
+       "      <td>0.05516810232865149</td>\n",
+       "      <td>9.893880433362487</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>1.2590469823779427</td>\n",
-       "      <td>-1.0</td>\n",
-       "      <td>0.14650229013911192</td>\n",
-       "      <td>10.69450056800893</td>\n",
+       "      <td>1.1450355702205555</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.07406373075546042</td>\n",
+       "      <td>10.575647402633352</td>\n",
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>1.1866208953876878</td>\n",
+       "      <td>1.1035420838861951</td>\n",
        "      <td>-0.5</td>\n",
-       "      <td>0.110686039247358</td>\n",
-       "      <td>10.842398294223246</td>\n",
+       "      <td>0.07968279966700363</td>\n",
+       "      <td>10.602712505218328</td>\n",
        "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>1.1742435439357988</td>\n",
+       "      <td>1.0960322683864845</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.09990384740748005</td>\n",
-       "      <td>10.842398294223246</td>\n",
+       "      <td>0.08011645599754529</td>\n",
+       "      <td>10.61847326104013</td>\n",
        "      <td>4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>1.1609903534788497</td>\n",
-       "      <td>-0.5</td>\n",
-       "      <td>0.0956691358037155</td>\n",
-       "      <td>10.822819559705623</td>\n",
+       "      <td>1.0905355533494399</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.08026433238349577</td>\n",
+       "      <td>10.645524685257502</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -856,13 +881,13 @@
        "</div>"
       ],
       "text/plain": [
-       "                  mse  homogeneity   jaccard_similarity                afsr  \\\n",
+       "                  mse  homogeneity       rec_similarity                afsr  \\\n",
        "0                None          NaN                 None                None   \n",
-       "1  1.5139009543444946        -45.5    1.000000000000011   9.475716982097305   \n",
-       "2  1.2590469823779427         -1.0  0.14650229013911192   10.69450056800893   \n",
-       "3  1.1866208953876878         -0.5    0.110686039247358  10.842398294223246   \n",
-       "4  1.1742435439357988          0.0  0.09990384740748005  10.842398294223246   \n",
-       "5  1.1609903534788497         -0.5   0.0956691358037155  10.822819559705623   \n",
+       "1  1.3177271448229297        -49.0  0.05516810232865149   9.893880433362487   \n",
+       "2  1.1450355702205555          1.0  0.07406373075546042  10.575647402633352   \n",
+       "3  1.1035420838861951         -0.5  0.07968279966700363  10.602712505218328   \n",
+       "4  1.0960322683864845          0.0  0.08011645599754529   10.61847326104013   \n",
+       "5  1.0905355533494399          0.0  0.08026433238349577  10.645524685257502   \n",
        "\n",
        "   timesteps  \n",
        "0          0  \n",
@@ -873,7 +898,7 @@
        "5          5  "
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -908,19 +933,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
-     "ename": "ValueError",
-     "evalue": "No measurement module defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-21-8c2ac2c003f6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0msystem_state\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfiltering\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_system_state\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"These are the system state components being monitored:\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msystem_state\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkeys\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Documents/CITP/Research/Github/t-recs/trecs/models/recommender.py\u001b[0m in \u001b[0;36mget_system_state\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    614\u001b[0m         \"\"\"\n\u001b[1;32m    615\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_system_state\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m<\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 616\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"No measurement module defined\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    617\u001b[0m         \u001b[0mstate\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    618\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0mcomponent\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_system_state\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mValueError\u001b[0m: No measurement module defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "These are the system state components being monitored:\n",
+      "dict_keys(['predicted_user_profiles', 'actual_user_scores', 'items', 'predicted_user_scores', 'timesteps'])\n"
      ]
     }
    ],
@@ -932,15 +953,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "There are as many states as the timesteps for which we ran the system + the initial state.\n",
+      "For example, the history of predicted_user_profiles has length: 6\n",
+      "Furthermore, the last state is in the history of a component corresponds to its current state.\n",
+      "Is this true for predicted_user_profiles? True\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"There are as many states as the timesteps for which we ran the system + the initial state.\")\n",
     "print(\"For example, the history of predicted_user_profiles has length:\", (len(system_state['predicted_user_profiles'])))\n",
     "# the last states correspond to the current state of the components\n",
     "print(\"Furthermore, the last state is in the history of a component corresponds to its current state.\")\n",
-    "print(\"Is this true for predicted_user_profiles?\", np.array_equal(system_state['predicted_user_profiles'][5], filtering.user_profiles))"
+    "print(\"Is this true for predicted_user_profiles?\", np.array_equal(system_state['predicted_user_profiles'][5], filtering.users_hat))"
    ]
   },
   {
@@ -993,9 +1025,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "trecsEnv",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "trecsenv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/trecs/components/users.py
+++ b/trecs/components/users.py
@@ -148,7 +148,7 @@ class Users(BaseComponent):  # pylint: disable=too-many-ancestors
             candidate item. The score function should take as input
             user_profiles and item_attributes.
 
-        repeat_items: bool (optional, default: True)
+        repeat_interactions: bool (optional, default: True)
             If `True`, then users will interact with items regardless of whether
             they have already interacted with them before. If `False`, users
             will not perform repeat interactions.
@@ -175,7 +175,7 @@ class Users(BaseComponent):  # pylint: disable=too-many-ancestors
         verbose=False,
         seed=None,
         attention_exp=0.0,
-        repeat_items=True,
+        repeat_interactions=True,
     ):  # pylint: disable=too-many-arguments
         self.rng = Generator(seed=seed)
         # general input checks
@@ -209,8 +209,8 @@ class Users(BaseComponent):  # pylint: disable=too-many-ancestors
         self.score_fn = score_fn  # function that dictates how scores will be generated
         self.actual_user_scores = actual_user_scores
         self.user_vector = np.arange(num_users, dtype=int)
-        self.repeat_items = repeat_items
-        if not repeat_items:
+        self.repeat_interactions = repeat_interactions
+        if not repeat_interactions:
             self.user_interactions = np.array([], dtype=int).reshape((num_users, 0))
         self.name = "actual_user_scores"
         BaseComponent.__init__(self, verbose=verbose, init_value=self.actual_user_scores)
@@ -351,7 +351,7 @@ class Users(BaseComponent):  # pylint: disable=too-many-ancestors
         reshaped_user_vector = self.user_vector.reshape((-1, 1))  # turn into column
 
         user_item_scores = self.actual_user_scores
-        if not self.repeat_items:
+        if not self.repeat_interactions:
             # scores for items already interacted with go to negative infinity
             num_past_interactions = self.user_interactions.shape[1]
             user_rows = np.tile(reshaped_user_vector, num_past_interactions)
@@ -379,7 +379,7 @@ class Users(BaseComponent):  # pylint: disable=too-many-ancestors
             # update user scores
             self.compute_user_scores(item_attributes)
         # record interactions if needed to ensure users don't repeat interactions
-        if not self.repeat_items:
+        if not self.repeat_interactions:
             interactions_col = interactions.reshape((-1, 1))
             # append interactions as column of user interactions
             self.user_interactions = np.hstack([self.user_interactions, interactions_col])

--- a/trecs/components/users.py
+++ b/trecs/components/users.py
@@ -175,7 +175,7 @@ class Users(BaseComponent):  # pylint: disable=too-many-ancestors
         verbose=False,
         seed=None,
         attention_exp=0.0,
-        repeat_items=True
+        repeat_items=True,
     ):  # pylint: disable=too-many-arguments
         self.rng = Generator(seed=seed)
         # general input checks
@@ -348,14 +348,14 @@ class Users(BaseComponent):  # pylint: disable=too-many-ancestors
         item_attributes = kwargs.pop("item_attributes", None)
         if items_shown is None:
             raise ValueError("Items can't be None")
-        reshaped_user_vector = self.user_vector.reshape((-1, 1)) # turn into column
+        reshaped_user_vector = self.user_vector.reshape((-1, 1))  # turn into column
 
         user_item_scores = self.actual_user_scores
         if not self.repeat_items:
             # scores for items already interacted with go to negative infinity
             num_past_interactions = self.user_interactions.shape[1]
             user_rows = np.tile(reshaped_user_vector, num_past_interactions)
-            user_item_scores[user_rows, self.user_interactions] = float('-inf')
+            user_item_scores[user_rows, self.user_interactions] = float("-inf")
 
         item_scores = user_item_scores[reshaped_user_vector, items_shown]
         if self.attention_exp != 0:

--- a/trecs/components/users.py
+++ b/trecs/components/users.py
@@ -367,7 +367,7 @@ class Users(BaseComponent):  # pylint: disable=too-many-ancestors
         interactions = items_shown[self.user_vector, sorted_user_preferences]
         # logging information if requested
         if self.is_verbose():
-            self.log(f"User scores for given items are:\n{str(user_interactions)}")
+            self.log(f"User scores for given items are:\n{str(item_scores)}")
             self.log(f"Users interact with the following items respectively:\n{str(interactions)}")
         if self.drift > 0:
             if item_attributes is None:

--- a/trecs/models/bass.py
+++ b/trecs/models/bass.py
@@ -126,6 +126,7 @@ class BassModel(BaseRecommender, BinarySocialGraph):
         actual_item_representation=None,
         probabilistic_recommendations=False,
         verbose=False,
+        measurements=None,
         num_items_per_iter=1,
         seed=None,
         **kwargs
@@ -208,7 +209,8 @@ class BassModel(BaseRecommender, BinarySocialGraph):
 
         self.infection_state = InfectionState(infection_state)
         self.infection_thresholds = InfectionThresholds(infection_thresholds)
-        measurements = [StructuralVirality(np.copy(infection_state))]
+        if measurements is None:
+            measurements = [StructuralVirality(np.copy(infection_state))]
         system_state = [self.infection_state]
         # Initialize recommender system
         # NOTE: Forcing to 1 item per iteration

--- a/trecs/models/content.py
+++ b/trecs/models/content.py
@@ -213,4 +213,4 @@ class ContentFiltering(BaseRecommender):
                 An array of items that represents new items that are being
                 added into the system. Should be :math:`|A|\\times|I|`
         """
-        self.items_hat = np.hstack([self.items_hat, new_items])
+        return new_items

--- a/trecs/models/content.py
+++ b/trecs/models/content.py
@@ -162,8 +162,6 @@ class ContentFiltering(BaseRecommender):
         if actual_item_representation is None:
             actual_item_representation = np.copy(item_representation)
 
-        measurements = [MSEMeasurement()]
-
         # Initialize recommender system
         BaseRecommender.__init__(
             self,
@@ -175,7 +173,6 @@ class ContentFiltering(BaseRecommender):
             num_items,
             num_items_per_iter,
             probabilistic_recommendations=probabilistic_recommendations,
-            measurements=measurements,
             verbose=verbose,
             seed=seed,
             **kwargs

--- a/trecs/models/content.py
+++ b/trecs/models/content.py
@@ -199,7 +199,7 @@ class ContentFiltering(BaseRecommender):
         interactions_per_user = np.zeros((self.num_users, self.num_items))
         interactions_per_user[self.users.user_vector, interactions] = 1
         user_attributes = np.dot(interactions_per_user, self.items_hat.T)
-        self.users_hat += user_attributes
+        np.add(self.users_hat, user_attributes, out=self.users_hat, casting="unsafe")
 
     def process_new_items(self, new_items):
         """

--- a/trecs/models/mf.py
+++ b/trecs/models/mf.py
@@ -291,6 +291,9 @@ class ImplicitMF(BaseRecommender):
         a model has already been fit prior to new items being created.
         """
         num_new_items = new_items.shape[1]
-        avg_item = self.als_model.item_features_.T.mean(axis=1)
+        if self.als_model:
+            avg_item = self.als_model.item_features_.T.mean(axis=1)
+        else:
+            avg_item = np.zeros((num_new_items, self.num_latent_factors))
         new_items = np.tile(avg_item, (num_new_items, 1)).T
         self.items_hat = np.hstack([self.items_hat, new_items])

--- a/trecs/models/mf.py
+++ b/trecs/models/mf.py
@@ -296,4 +296,4 @@ class ImplicitMF(BaseRecommender):
         else:
             avg_item = np.zeros((num_new_items, self.num_latent_factors))
         new_items = np.tile(avg_item, (num_new_items, 1)).T
-        self.items_hat = np.hstack([self.items_hat, new_items])
+        return new_items

--- a/trecs/models/mf.py
+++ b/trecs/models/mf.py
@@ -195,8 +195,6 @@ class ImplicitMF(BaseRecommender):
         if actual_item_representation is None:
             actual_item_representation = np.copy(item_representation)
 
-        measurements = [MSEMeasurement()]
-
         super().__init__(
             user_representation,
             item_representation,
@@ -206,7 +204,6 @@ class ImplicitMF(BaseRecommender):
             num_items,
             num_items_per_iter,
             probabilistic_recommendations=probabilistic_recommendations,
-            measurements=measurements,
             verbose=verbose,
             seed=seed,
             **kwargs

--- a/trecs/models/mf.py
+++ b/trecs/models/mf.py
@@ -294,6 +294,6 @@ class ImplicitMF(BaseRecommender):
         if self.als_model:
             avg_item = self.als_model.item_features_.T.mean(axis=1)
         else:
-            avg_item = np.zeros((num_new_items, self.num_latent_factors))
+            avg_item = np.zeros(self.num_latent_factors)
         new_items = np.tile(avg_item, (num_new_items, 1)).T
         return new_items

--- a/trecs/models/popularity.py
+++ b/trecs/models/popularity.py
@@ -148,8 +148,6 @@ class PopularityRecommender(BaseRecommender):
         if user_representation is None:
             user_representation = np.ones((num_users, num_attributes), dtype=int)
 
-        measurements = [MSEMeasurement()]
-
         super().__init__(
             user_representation,
             item_representation,
@@ -159,7 +157,6 @@ class PopularityRecommender(BaseRecommender):
             num_items,
             num_items_per_iter,
             probabilistic_recommendations=probabilistic_recommendations,
-            measurements=measurements,
             verbose=verbose,
             seed=seed,
             **kwargs

--- a/trecs/models/popularity.py
+++ b/trecs/models/popularity.py
@@ -179,4 +179,4 @@ class PopularityRecommender(BaseRecommender):
         """
         # start popularity of new items as 0
         new_representation = np.zeros(new_items.shape[1]).reshape(1, -1)
-        self.items_hat = np.hstack([self.items_hat, new_representation])
+        return new_representation

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -360,7 +360,7 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
             if self.is_verbose():
                 self.log(f"Item indices:\n{str(item_indices)}")
                 self.log(
-                    f"Top-k items ordered by preference (low to high) for each user:\n{str(rec)}"
+                    f"Top-k items ordered by preference (high to low) for each user:\n{str(rec)}"
                 )
             return rec
 

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -578,6 +578,12 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
         # have users update their own scores too
         self.users.score_new_items(new_items)
 
+    def set_num_items_per_iter(self, num_items_per_iter):
+        """ Change the number of items that will be shown
+            to each user per iteration.
+        """
+        self.num_items_per_iter = num_items_per_iter
+
     def add_new_item_indices(self, num_new_items):
         """
         Expands the indices matrix to include entries for new items that

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -373,7 +373,14 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
     def choose_interleaved_items(self, k, item_indices):
         """
         Chooses k items out of the item set to "interleave" into
-        the system's recommendations. **NOTE**: Currently, there
+        the system's recommendations. In this case, we define "interleaving"
+        as a process by which items can be inserted into the set of items
+        shown to the user, in addition to the recommended items that
+        maximize the predicted score. For example, users may want to insert
+        random interleaved items to increase the "exploration" of the
+        recommender system, or may want to ensure that new items are always
+        interleaved into the item set shown to users.
+        **NOTE**: Currently, there
         is no guarantee that items that are interleaved are distinct
         from the recommended items. We do guarantee that within the
         set of items interleaved for a particular user, there are no

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -137,6 +137,15 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
             Function that is used to calculate each user's predicted scores for
             each candidate item. The score function should take as input
             user_profiles and item_attributes.
+
+        interleaving_fn: callable
+            Function that is used to determine the indices of items that will be
+            interleaved into the recommender system's recommendations. The
+            interleaving function should take as input an integer `k` (representing
+            the number of items to be interleaved in every recommendation set) and
+            a matrix `item_indices` (representing which items are eligible to be
+            interleaved). The function should return a :math:`|U|\\times k` matrix
+            representing the interleaved items for each user.
     """
 
     @abstractmethod

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -464,7 +464,7 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
 
         interleaved_items = self.choose_interleaved_items(num_new_items, item_indices)
 
-        items = np.random_state.rand((self.num_users, self.num_items_per_iter))
+        items = np.zeros((self.num_users, self.num_items_per_iter), dtype=int)
         # generate indices for recommended and randomly interleaved columns
         col_idxs = np.zeros(self.num_items_per_iter, dtype=bool)
         rand_col_idxs = self.random_state.choice(

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -5,6 +5,7 @@ implementable in our simulation library
 from abc import ABC, abstractmethod
 import numpy as np
 from tqdm import tqdm
+import warnings
 from trecs.metrics import MeasurementModule
 from trecs.components import (
     Users,
@@ -560,6 +561,12 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
                 can be helpful, say, during a "training" period where no new items should be
                 made.
         """
+        if len(self.metrics) == 0: # warn user if no measurements are defined
+            error_msg = (
+                "No measurements are currently defined for the simulation. Please add "
+                "measurements if desired."
+            )
+            warnings.warn(error_msg)
         if not startup and self.is_verbose():
             self.log("Running recommendation simulation using recommendation algorithm...")
         for timestep in tqdm(range(timesteps)):
@@ -674,7 +681,7 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
         Monitored measurements: dict
         """
         if len(self.metrics) < 1:
-            raise ValueError("No measurement module defined")
+            return None
         measurements = dict()
         for metric in self.metrics:
             measurements = {**measurements, **metric.get_measurement()}

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -349,14 +349,16 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
             # scores are U x I; we can use argpartition to take the top k scores
             negated_scores = -1 * s_filtered  # negate scores so indices go from highest to lowest
             # break ties using a random score component
-            scores_tiebreak = np.zeros(negated_scores.shape, dtype=[('score', 'f8'), ('random', 'f8')])
-            scores_tiebreak['score'] = negated_scores
-            scores_tiebreak['random'] = self.random_state.random(negated_scores.shape)
-            top_k = scores_tiebreak.argpartition(k - 1, order=['score', 'random'])[:, :k]
+            scores_tiebreak = np.zeros(
+                negated_scores.shape, dtype=[("score", "f8"), ("random", "f8")]
+            )
+            scores_tiebreak["score"] = negated_scores
+            scores_tiebreak["random"] = self.random_state.random(negated_scores.shape)
+            top_k = scores_tiebreak.argpartition(k - 1, order=["score", "random"])[:, :k]
             # now we sort within the top k
             row = np.repeat(self.users.user_vector, k).reshape((self.num_users, -1))
             # again, indices should go from highest to lowest
-            sort_top_k = scores_tiebreak[row, top_k].argsort(order=['score', 'random'])
+            sort_top_k = scores_tiebreak[row, top_k].argsort(order=["score", "random"])
             rec = item_indices[
                 row, top_k[row, sort_top_k]
             ]  # extract items such that rows go from highest scored to lowest-scored of top-k
@@ -566,8 +568,8 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
             if self.creators is not None and not no_new_items:
                 self.create_and_process_items()
                 if self.expand_items_per_iter:
-                        # expand set of items recommended per iteration
-                        self.num_items_per_iter = self.num_items
+                    # expand set of items recommended per iteration
+                    self.num_items_per_iter = self.num_items
             item_idxs = self.recommend(
                 startup=startup,
                 random_items_per_iter=random_items_per_iter,

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -569,7 +569,7 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
                 self.create_and_process_items()
                 if self.expand_items_per_iter:
                     # expand set of items recommended per iteration
-                    self.num_items_per_iter = self.num_items
+                    self.set_num_items_per_iter("all")
             item_idxs = self.recommend(
                 startup=startup,
                 random_items_per_iter=random_items_per_iter,

--- a/trecs/models/recommender.py
+++ b/trecs/models/recommender.py
@@ -3,9 +3,9 @@ BaseRecommender, the foundational class for all recommender systems
 implementable in our simulation library
 """
 from abc import ABC, abstractmethod
+import warnings
 import numpy as np
 from tqdm import tqdm
-import warnings
 from trecs.metrics import MeasurementModule
 from trecs.components import (
     Users,
@@ -568,7 +568,7 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
                 can be helpful, say, during a "training" period where no new items should be
                 made.
         """
-        if len(self.metrics) == 0: # warn user if no measurements are defined
+        if len(self.metrics) == 0:  # warn user if no measurements are defined
             error_msg = (
                 "No measurements are currently defined for the simulation. Please add "
                 "measurements if desired."

--- a/trecs/models/social.py
+++ b/trecs/models/social.py
@@ -211,9 +211,8 @@ class SocialFiltering(BaseRecommender, BinarySocialGraph):
 
     def process_new_items(self, new_items):
         """
-        We assume the content filtering system has perfect knowledge
-        of the new items; therefore, when new items are created,
-        we simply return the new item attributes.
+        New items are simply represented as zeros, since they have not received
+        interactions from any users yet.
 
         Parameters:
         ------------
@@ -223,4 +222,4 @@ class SocialFiltering(BaseRecommender, BinarySocialGraph):
         """
         # users have never interacted with new items
         new_representation = np.zeros((self.num_users, new_items.shape[1]))
-        self.items_hat = np.hstack([self.items_hat, new_representation])
+        return new_representation

--- a/trecs/models/social.py
+++ b/trecs/models/social.py
@@ -175,7 +175,6 @@ class SocialFiltering(BaseRecommender, BinarySocialGraph):
         if actual_item_representation is None:
             actual_item_representation = np.copy(item_representation)
 
-        measurements = [MSEMeasurement()]
         # Initialize recommender system
         BaseRecommender.__init__(
             self,
@@ -188,7 +187,6 @@ class SocialFiltering(BaseRecommender, BinarySocialGraph):
             num_items_per_iter,
             probabilistic_recommendations=probabilistic_recommendations,
             seed=seed,
-            measurements=measurements,
             verbose=verbose,
             **kwargs
         )

--- a/trecs/tests/test_BassModel.py
+++ b/trecs/tests/test_BassModel.py
@@ -1,3 +1,4 @@
+from trecs.metrics.measurement import MSEMeasurement
 import test_helpers
 import numpy as np
 from trecs.models import BassModel
@@ -175,7 +176,9 @@ class TestBassModel:
         if seed is None:
             seed = np.random.randint(100000)
         s1 = BassModel(seed=seed, record_base_state=True)
+        s1.add_metrics(MSEMeasurement())
         s2 = BassModel(seed=seed, record_base_state=True)
+        s2.add_metrics(MSEMeasurement())
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)
@@ -193,7 +196,9 @@ class TestBassModel:
         if users is None:
             users = np.random.randint(1, 100)
         s1 = BassModel(seed=seed, num_users=users, num_items=items, record_base_state=True)
+        s1.add_metrics(MSEMeasurement())
         s2 = BassModel(seed=seed, num_users=users, num_items=items, record_base_state=True)
+        s2.add_metrics(MSEMeasurement())
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)

--- a/trecs/tests/test_ContentFiltering.py
+++ b/trecs/tests/test_ContentFiltering.py
@@ -1,4 +1,5 @@
 from attr import attrs
+from trecs.metrics.measurement import MSEMeasurement
 from trecs.models import ContentFiltering
 from trecs.components import Users, Creators
 import numpy as np
@@ -225,7 +226,9 @@ class TestContentFiltering:
         if seed is None:
             seed = np.random.randint(100000)
         s1 = ContentFiltering(seed=seed, record_base_state=True)
+        s1.add_metrics(MSEMeasurement())
         s2 = ContentFiltering(seed=seed, record_base_state=True)
+        s2.add_metrics(MSEMeasurement())
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)
@@ -243,7 +246,9 @@ class TestContentFiltering:
         if users is None:
             users = np.random.randint(1, 100)
         s1 = ContentFiltering(seed=seed, num_users=users, num_items=items, record_base_state=True)
+        s1.add_metrics(MSEMeasurement())
         s2 = ContentFiltering(seed=seed, num_users=users, num_items=items, record_base_state=True)
+        s2.add_metrics(MSEMeasurement())
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)

--- a/trecs/tests/test_PopularityRecommender.py
+++ b/trecs/tests/test_PopularityRecommender.py
@@ -1,3 +1,4 @@
+from trecs.metrics.measurement import MSEMeasurement
 from trecs.models import PopularityRecommender
 from trecs.components import Creators
 import numpy as np
@@ -114,7 +115,9 @@ class TestPopularityRecommender:
         if seed is None:
             seed = np.random.randint(100000)
         s1 = PopularityRecommender(seed=seed, record_base_state=True)
+        s1.add_metrics(MSEMeasurement())
         s2 = PopularityRecommender(seed=seed, record_base_state=True)
+        s2.add_metrics(MSEMeasurement())
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)
@@ -134,9 +137,11 @@ class TestPopularityRecommender:
         s1 = PopularityRecommender(
             seed=seed, num_users=users, num_items=items, record_base_state=True
         )
+        s1.add_metrics(MSEMeasurement())
         s2 = PopularityRecommender(
             seed=seed, num_users=users, num_items=items, record_base_state=True
         )
+        s2.add_metrics(MSEMeasurement())
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)

--- a/trecs/tests/test_SocialFiltering.py
+++ b/trecs/tests/test_SocialFiltering.py
@@ -1,5 +1,6 @@
 import test_helpers
 import numpy as np
+from trecs.metrics.measurement import MSEMeasurement
 from trecs.models import SocialFiltering
 from trecs.components import Creators
 import pytest
@@ -186,7 +187,9 @@ class TestSocialFiltering:
         if seed is None:
             seed = np.random.randint(100000)
         s1 = SocialFiltering(seed=seed, record_base_state=True)
+        s1.add_metrics(MSEMeasurement())
         s2 = SocialFiltering(seed=seed, record_base_state=True)
+        s2.add_metrics(MSEMeasurement())
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)
@@ -204,7 +207,9 @@ class TestSocialFiltering:
         if users is None:
             users = np.random.randint(1, 100)
         s1 = SocialFiltering(seed=seed, num_users=users, num_items=items, record_base_state=True)
+        s1.add_metrics(MSEMeasurement())
         s2 = SocialFiltering(seed=seed, num_users=users, num_items=items, record_base_state=True)
+        s2.add_metrics(MSEMeasurement())
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
         s1.run(timesteps=5)

--- a/trecs/tests/test_Users.py
+++ b/trecs/tests/test_Users.py
@@ -115,3 +115,21 @@ class TestUsers:
         users.compute_user_scores(items)
         feedback = users.get_user_feedback(items_shown=items_shown)
         np.testing.assert_array_equal(feedback, np.ones(num_users))
+
+    def test_no_repeated_items(self):
+        num_users = 5
+        num_attr = 4
+        num_items = 5
+        users = Users(np.ones((num_users, num_attr)), repeat_items=False)
+        # first item is most desirable because its attributes are all 0,
+        # second item is second most desirable because attributes are all -1, etc.
+        items = np.tile(np.arange(num_items) * -1, (num_attr, 1))
+        users.compute_user_scores(items)
+        items_shown = np.tile(np.arange(num_items), (num_users, 1)) # all items shown to all users
+        # all users should like the 0th item best
+        feedback = users.get_user_feedback(items_shown=items_shown)
+        np.testing.assert_array_equal(feedback, np.zeros(num_users))
+        # all users should then like the 1st item, since they're not
+        # allowed to repeat interactions
+        feedback = users.get_user_feedback(items_shown=items_shown)
+        np.testing.assert_array_equal(feedback, np.ones(num_users))

--- a/trecs/tests/test_Users.py
+++ b/trecs/tests/test_Users.py
@@ -120,7 +120,7 @@ class TestUsers:
         num_users = 5
         num_attr = 4
         num_items = 5
-        users = Users(np.ones((num_users, num_attr)), repeat_items=False)
+        users = Users(np.ones((num_users, num_attr)), repeat_interactions=False)
         # first item is most desirable because its attributes are all 0,
         # second item is second most desirable because attributes are all -1, etc.
         items = np.tile(np.arange(num_items) * -1, (num_attr, 1))

--- a/trecs/tests/test_Users.py
+++ b/trecs/tests/test_Users.py
@@ -125,7 +125,7 @@ class TestUsers:
         # second item is second most desirable because attributes are all -1, etc.
         items = np.tile(np.arange(num_items) * -1, (num_attr, 1))
         users.compute_user_scores(items)
-        items_shown = np.tile(np.arange(num_items), (num_users, 1)) # all items shown to all users
+        items_shown = np.tile(np.arange(num_items), (num_users, 1))  # all items shown to all users
         # all users should like the 0th item best
         feedback = users.get_user_feedback(items_shown=items_shown)
         np.testing.assert_array_equal(feedback, np.zeros(num_users))

--- a/trecs/tests/test_measurements.py
+++ b/trecs/tests/test_measurements.py
@@ -2,7 +2,6 @@ import test_helpers
 import numpy as np
 from trecs.models import SocialFiltering, ContentFiltering, BassModel
 from trecs.metrics import (
-    Measurement,
     HomogeneityMeasurement,
     MSEMeasurement,
     DiffusionTreeMeasurement,
@@ -96,6 +95,7 @@ class TestMeasurementModule:
             MeasurementUtils.assert_valid_length(system_state, t)
 
         s = SocialFiltering()
+        s.add_metrics(MSEMeasurement())
 
         for t in range(1, timesteps + 1):
             s.run(timesteps=1)

--- a/trecs/tests/test_recommender.py
+++ b/trecs/tests/test_recommender.py
@@ -130,10 +130,17 @@ class TestBaseRecommender:
 
         items_per_iter = 15
         dummy = DummyRecommender(self.users_hat, self.items_hat, self.users, self.items, 10, 50, items_per_iter, seed=1234, interleaving_fn=custom_interleaving_fn)
-        recommended = dummy.recommend(random_items_per_iter=items_per_iter) # all recommendations will be interleaved
-        # sort recommended items so they go from 0 to 14
+        recommended = dummy.recommend(random_items_per_iter=items_per_iter) # all recommendations will be interleaved items
+        # we expect every user to be recommended the expected recommendations
+        assert (recommended == recommended[0]).all() # assert all rows are the same
+
+    def test_random_interleaving(self):
+        items_per_iter = 50 # recommend from the entire item set
+        dummy = DummyRecommender(self.users_hat, self.items_hat, self.users, self.items, 10, 50, items_per_iter, seed=1234)
+        recommended = dummy.recommend(random_items_per_iter=items_per_iter) # all recommendations will be interleaved items
+        # we expect every user to be recommended the expected recommendations but in different orders
         rec_sort = np.sort(recommended, axis=1)
-        expected_rec = np.arange(15)
-        # we expect every user to be recommended items in a different order
-        assert (rec_sort == expected_rec).all()
+        assert not (recommended == recommended[0]).all() # interleaved recommendations should have a random order
+        assert (rec_sort == rec_sort[0]).all() # assert all rows have the same set of interleaved items
+
 

--- a/trecs/tests/test_recommender.py
+++ b/trecs/tests/test_recommender.py
@@ -102,6 +102,20 @@ class TestBaseRecommender:
         # so instead we verify the sorted position of each item
         test_helpers.assert_equal_arrays(true_scores.argsort(), predicted_scores.argsort())
 
+    def test_all_items_per_iter(self):
+        # 10 content creators
+        creators = Creators(np.random.uniform(size=(10, 5)), creation_probability=1)
+        dummy = DummyRecommender(
+            self.users_hat, self.items_hat, self.users, self.items, 10, 50, "all", creators=creators
+        )
+        assert dummy.num_items_per_iter == 50
+        dummy.run(1, repeated_items=True)  # run 5 timesteps
+        assert dummy.num_items_per_iter == 60
+        dummy.run(1, repeated_items=True)  # run 5 timesteps
+        assert dummy.num_items_per_iter == 70
+        recommended = dummy.recommend()
+        assert recommended.shape[1] == 70 # assert recommendaitons are proper length
+
     def test_random_tiebreak(self):
         self.items_hat = np.zeros(self.items_hat.shape) # all item/users should have the same score
         dummy = DummyRecommender(self.users_hat, self.items_hat, self.users, self.items, 10, 50, 5, seed=1234)

--- a/trecs/tests/test_recommender.py
+++ b/trecs/tests/test_recommender.py
@@ -122,3 +122,18 @@ class TestBaseRecommender:
         recommended = dummy.generate_recommendations(k=5, item_indices=dummy.indices)
         # we expect every user to be recommended items in a different order
         assert not (recommended == recommended[0]).all()
+
+    def test_interleaving_fn(self):
+        def custom_interleaving_fn(k, item_indices):
+            # toy interleaving function that returns the first k indices
+            return item_indices[:, :k]
+
+        items_per_iter = 15
+        dummy = DummyRecommender(self.users_hat, self.items_hat, self.users, self.items, 10, 50, items_per_iter, seed=1234, interleaving_fn=custom_interleaving_fn)
+        recommended = dummy.recommend(random_items_per_iter=items_per_iter) # all recommendations will be interleaved
+        # sort recommended items so they go from 0 to 14
+        rec_sort = np.sort(recommended, axis=1)
+        expected_rec = np.arange(15)
+        # we expect every user to be recommended items in a different order
+        assert (rec_sort == expected_rec).all()
+

--- a/trecs/tests/test_recommender.py
+++ b/trecs/tests/test_recommender.py
@@ -114,11 +114,13 @@ class TestBaseRecommender:
         dummy.run(1, repeated_items=True)  # run 5 timesteps
         assert dummy.num_items_per_iter == 70
         recommended = dummy.recommend()
-        assert recommended.shape[1] == 70 # assert recommendaitons are proper length
+        assert recommended.shape[1] == 70  # assert recommendaitons are proper length
 
     def test_random_tiebreak(self):
-        self.items_hat = np.zeros(self.items_hat.shape) # all item/users should have the same score
-        dummy = DummyRecommender(self.users_hat, self.items_hat, self.users, self.items, 10, 50, 5, seed=1234)
+        self.items_hat = np.zeros(self.items_hat.shape)  # all item/users should have the same score
+        dummy = DummyRecommender(
+            self.users_hat, self.items_hat, self.users, self.items, 10, 50, 5, seed=1234
+        )
         recommended = dummy.generate_recommendations(k=5, item_indices=dummy.indices)
         # we expect every user to be recommended items in a different order
         assert not (recommended == recommended[0]).all()
@@ -129,18 +131,43 @@ class TestBaseRecommender:
             return item_indices[:, :k]
 
         items_per_iter = 15
-        dummy = DummyRecommender(self.users_hat, self.items_hat, self.users, self.items, 10, 50, items_per_iter, seed=1234, interleaving_fn=custom_interleaving_fn)
-        recommended = dummy.recommend(random_items_per_iter=items_per_iter) # all recommendations will be interleaved items
+        dummy = DummyRecommender(
+            self.users_hat,
+            self.items_hat,
+            self.users,
+            self.items,
+            10,
+            50,
+            items_per_iter,
+            seed=1234,
+            interleaving_fn=custom_interleaving_fn,
+        )
+        recommended = dummy.recommend(
+            random_items_per_iter=items_per_iter
+        )  # all recommendations will be interleaved items
         # we expect every user to be recommended the expected recommendations
-        assert (recommended == recommended[0]).all() # assert all rows are the same
+        assert (recommended == recommended[0]).all()  # assert all rows are the same
 
     def test_random_interleaving(self):
-        items_per_iter = 50 # recommend from the entire item set
-        dummy = DummyRecommender(self.users_hat, self.items_hat, self.users, self.items, 10, 50, items_per_iter, seed=1234)
-        recommended = dummy.recommend(random_items_per_iter=items_per_iter) # all recommendations will be interleaved items
+        items_per_iter = 50  # recommend from the entire item set
+        dummy = DummyRecommender(
+            self.users_hat,
+            self.items_hat,
+            self.users,
+            self.items,
+            10,
+            50,
+            items_per_iter,
+            seed=1234,
+        )
+        recommended = dummy.recommend(
+            random_items_per_iter=items_per_iter
+        )  # all recommendations will be interleaved items
         # we expect every user to be recommended the expected recommendations but in different orders
         rec_sort = np.sort(recommended, axis=1)
-        assert not (recommended == recommended[0]).all() # interleaved recommendations should have a random order
-        assert (rec_sort == rec_sort[0]).all() # assert all rows have the same set of interleaved items
-
-
+        assert not (
+            recommended == recommended[0]
+        ).all()  # interleaved recommendations should have a random order
+        assert (
+            rec_sort == rec_sort[0]
+        ).all()  # assert all rows have the same set of interleaved items

--- a/trecs/tests/test_recommender.py
+++ b/trecs/tests/test_recommender.py
@@ -19,7 +19,7 @@ class DummyRecommender(BaseRecommender):
         # generate a representation of ones
         num_attr = self.items.shape[0]
         num_items = new_items.shape[1]
-        self.items_hat = np.hstack([self.items_hat, np.random.uniform(size=(num_attr, num_items))])
+        return np.random.uniform(size=(num_attr, num_items))
 
 
 class TestBaseRecommender:

--- a/trecs/tests/test_recommender.py
+++ b/trecs/tests/test_recommender.py
@@ -101,3 +101,10 @@ class TestBaseRecommender:
         # the predicted scores normalize the user arrays before doing the dot product,
         # so instead we verify the sorted position of each item
         test_helpers.assert_equal_arrays(true_scores.argsort(), predicted_scores.argsort())
+
+    def test_random_tiebreak(self):
+        self.items_hat = np.zeros(self.items_hat.shape) # all item/users should have the same score
+        dummy = DummyRecommender(self.users_hat, self.items_hat, self.users, self.items, 10, 50, 5, seed=1234)
+        recommended = dummy.generate_recommendations(k=5, item_indices=dummy.indices)
+        # we expect every user to be recommended items in a different order
+        assert not (recommended == recommended[0]).all()


### PR DESCRIPTION
Woo! Adding a bunch of features into T-RECs/slightly rejigging parts of the system so it has the necessary flexibility to accommodate all of the Chaney study design.

- Adding a `repeat_items` flag in the `Users` class that modifies user behavior such that they do not interact with items they've already interacted with in the past
- Remove `MSEMeasurement` as the default in every model, and allow user to pass in an arbitrary list of measurements that they'd prefer to pass in. (I kept `StructuralVirality` as a default measurement for `BassModel`, but I think this should actually be removed as well...)
- Modify `process_new_items` method in every model slightly such that it only returns the `items_hat` representation of the new items in the simulation. This just makes things cleaner in the `create_and_process_items` method
- Previously, I was calling the `train()` method after new items were created as a shortcut for generating the predicted score on new items. While this worked internally, it's a bit semantically confusing when users might expect `train` to be called only once per iteration. So I removed the call to `train()` and did something a bit more efficient, which was calculate scores using the `score_fn` only on new items and then concatenate these new scores to `self.predicted_scores`
- Add a new option for users to pass in `num_items_per_iter="all"` in order for the system to serve recommendations from the set of all items in the item set, rather than a fixed number of items to serve per iteration. This makes sense when the number of items is changing (i.e., with content creators)
- Added a new method called `set_num_items_per_iter` that makes it easy for the user to change the number of items served per iteration 
- Allow user to pass in a custom `interleaving_fn` that returns the set of items to be randomly interleaved with the system's recommendations; by default, if there is no interleaving function, the set of items is randomly chosen for each user
- When recommending items to users, break ties randomly (i.e., if two items have the same predicted score for a user, they should be recommended in a random order)
... plus yummy tests for the things mentioned above!