### PR TITLE
Switch content filtering model to use NNLS solver by default

### DIFF
--- a/trecs/models/content.py
+++ b/trecs/models/content.py
@@ -205,16 +205,18 @@ class ContentFiltering(BaseRecommender):
 
     def train(self):
         """
-        TODO
+        Uses the NNLS solver to train the user representations, based on the user
+        interaction & item attribute data.
+
+        Note: this function may run slowly because it requires a manual loop over every
+        user.
         """
         if self.all_interactions is not None and self.all_interactions.sum() > 0: # if there are interactions present:
-            # import pdb; pdb.set_trace()
             for i in range(self.num_users):
                 item_attr = mo.to_dense(self.predicted_item_attributes.T) # convert to dense so nnls can be used
                 user_interactions = self.all_interactions[i, :].toarray()[0, :]
                 # solve for Content Filtering representation using nnls solver
                 self.users_hat.value[i, :] = nnls(item_attr, user_interactions)[0]
-            # import pdb; pdb.set_trace()
 
         super().train()
 

--- a/trecs/models/content.py
+++ b/trecs/models/content.py
@@ -200,7 +200,10 @@ class ContentFiltering(BaseRecommender):
                 the item that the user has interacted with.
 
         """
-        sparse_interactions = sp.csr_matrix((np.ones(interactions.shape), (self.users.user_vector, interactions)), self.all_interactions.shape)
+        sparse_interactions = sp.csr_matrix(
+            (np.ones(interactions.shape), (self.users.user_vector, interactions)),
+            self.all_interactions.shape,
+        )
         self.all_interactions = self.all_interactions + sparse_interactions
 
     def train(self):
@@ -211,9 +214,13 @@ class ContentFiltering(BaseRecommender):
         Note: this function may run slowly because it requires a manual loop over every
         user.
         """
-        if self.all_interactions is not None and self.all_interactions.sum() > 0: # if there are interactions present:
+        if (
+            self.all_interactions is not None and self.all_interactions.sum() > 0
+        ):  # if there are interactions present:
             for i in range(self.num_users):
-                item_attr = mo.to_dense(self.predicted_item_attributes.T) # convert to dense so nnls can be used
+                item_attr = mo.to_dense(
+                    self.predicted_item_attributes.T
+                )  # convert to dense so nnls can be used
                 user_interactions = self.all_interactions[i, :].toarray()[0, :]
                 # solve for Content Filtering representation using nnls solver
                 self.users_hat.value[i, :] = nnls(item_attr, user_interactions)[0]

--- a/trecs/tests/test_ContentFiltering.py
+++ b/trecs/tests/test_ContentFiltering.py
@@ -232,8 +232,8 @@ class TestContentFiltering:
         s2.add_metrics(MSEMeasurement())
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
-        s1.run(timesteps=5)
-        s2.run(timesteps=5)
+        s1.run(timesteps=2)
+        s2.run(timesteps=2)
         # check that measurements are the same
         meas1 = s1.get_measurements()
         meas2 = s2.get_measurements()
@@ -252,8 +252,8 @@ class TestContentFiltering:
         s2.add_metrics(MSEMeasurement())
         test_helpers.assert_equal_arrays(s1.items_hat, s2.items_hat)
         test_helpers.assert_equal_arrays(s1.users_hat, s2.users_hat)
-        s1.run(timesteps=5)
-        s2.run(timesteps=5)
+        s1.run(timesteps=2)
+        s2.run(timesteps=2)
         # check that measurements are the same
         meas1 = s1.get_measurements()
         meas2 = s2.get_measurements()


### PR DESCRIPTION
Previously, our content filtering model updated the user representation by adding the most recently interacted item to the user's matrix representation. This is somewhat non-standard, so we've switched the default behavior to use the NNLS solver that is employed by Chaney et al. 2018 in their study on algorithmic confounding.

This behavior is a bit slower, so we've also cut down on the number of timesteps in some of the tests.

Finally, to verify that this content filtering approach works, I re-ran some simulations from [our Chaney replication](https://github.com/sunnymatt/t-recs-experiments) and found that, at least on a cursory level, this NNLS solver produces the same results (by visual inspection of the resulting graphs). So this means that this interpretation is equivalent to the Chaney replication implementation.